### PR TITLE
Update the API version in the Scrapper.php file

### DIFF
--- a/src/Scraper.php
+++ b/src/Scraper.php
@@ -12,7 +12,7 @@ use projectivemotion\PhpScraperTools\CacheScraper;
 
 class Scraper extends CacheScraper
 {
-    const default_api_version = '3.8.2';
+    const default_api_version = '6.6.2';
     protected $protocol =   'https';
     protected $domain   =   'be.wizzair.com';
 


### PR DESCRIPTION
The API version in the Scrapper file was 3.8.2 which is causing search error and bad result ( it's returning HTML instead of JSON ) - changing the API version is fixing this issue.